### PR TITLE
changing deepsight borders to inset box-shadows

### DIFF
--- a/app/css/fateOfAllFools.css
+++ b/app/css/fateOfAllFools.css
@@ -87,5 +87,5 @@ td.min-light {
 
 .item[data-fate-deepsight=true]
 {
-  border: 2px solid rgba(210, 82, 58, 0.5);
+  box-shadow: inset 0px 0px 1px 2px rgb(210 82 58 / 100%);
 }


### PR DESCRIPTION
Simple change for the condition where "data-fate-deepsight=true"; for the weapons with deepsight on them.

Borders increase the total dimensions of the draggables. As an alternative, an inset box-shadow keeps the dimensions the same while delivering the same information. 

Used same colours with full opacity. Tested on Edge.